### PR TITLE
Input can be a path prefix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1088,9 +1088,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c4eb3267174b8c6c2f654116623910a0fef09c4753f8dd83db29c48a0df988b"
+checksum = "e076559ef8e241f2ae3479e36f97bd5741c0330689e217ad51ce2c76808b868a"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1239,6 +1239,7 @@ dependencies = [
  "pooled-writer",
  "rayon",
  "read-structure",
+ "regex",
  "rstest",
  "seq_io",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -943,6 +943,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "path-absolutize"
+version = "3.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f1d4993b16f7325d90c18c3c6a3327db7808752db8d208cea0acee0abd52c52"
+dependencies = [
+ "path-dedot",
+]
+
+[[package]]
+name = "path-dedot"
+version = "3.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a81540d94551664b72b72829b12bd167c73c9d25fbac0e04fafa8023f7e4901"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1236,6 +1254,7 @@ dependencies = [
  "mimalloc",
  "num_cpus",
  "parking_lot 0.11.2",
+ "path-absolutize",
  "pooled-writer",
  "rayon",
  "read-structure",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ parking_lot = "0.11.2"
 pooled-writer = "0.2.0"
 rayon = "1.5.1"
 read-structure = "0.1.0"
+regex = "1.7.0"
 seq_io = { git = "https://github.com/fulcrumgenomics/seq_io.git", rev = "3d461a3" }
 serde = { version = "1.0.130", features = ["derive"] }
 strum = { version = "0.24.0", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ log = "0.4.14"
 mimalloc = { version = "0.1.27", default-features = false }
 num_cpus = "1.13.0"
 parking_lot = "0.11.2"
+path-absolutize = "3.0.14"
 pooled-writer = "0.2.0"
 rayon = "1.5.1"
 read-structure = "0.1.0"

--- a/README.md
+++ b/README.md
@@ -127,21 +127,30 @@ for read in R1 R2 I1 I2; do cat L*/${read}.fastq.gz > ./${read}.fastq.gz; done
 
 FASTQ files _must_ be BGZF compressed.
 
-All reads containing sample barcodes/indexes _must_ be of the same length.
-
 ###### Auto-detecting FASTQS from a Path Prefix
 
 Alternatively, the FASTQS can be auto-detected when a path prefix is given to `--fastqs <dir>/<prefix>`.
 The FASTQs must be named `<dir>/<prefix>_L00<lane>_<kind><kind-number>_001.fastq.gz`, where `kind` is
 one of R (read/template), I (index/sample barcode), or U (umi/molecular barcode). 
 
-If the read structure is given on the command line or Sample sheet, the segments are assumed to to
-apply to I1 R1 R2 I2 reads in that order.  Otherwise, the read structure will be `B+ T+ T+ B+` 
-(all index bases are used for the sample barcode, all read bases are assumed to be template).
+The Read Structure must not be given on the the command line or Sample Sheet.  Instead, the Read 
+Structure will be derived file names (kind and kind number), with the full read length used for the given kind.
+E.g. if the following FASTQs are present with path prefix `/path/to/prefix`:
+
+```
+/path/to/prefix_L001_I1_001.fasztq.gz
+/path/to/prefix_L001_R1_001.fasztq.gz
+/path/to/prefix_L001_R2_001.fasztq.gz
+/path/to/prefix_L001_I2_001.fasztq.gz
+```
+
+then the `+B +T +T +B` read structure will be used.  Since this tool requires all sample barcode
+segments to have a fixed length, the first read in any index/sample-barcode FASTQ will be examined
+and its length used as the expected sample barcode length.
 
 ##### Read Structures
 
-Read Structures are short strings that describe the origin and/or purpose of bases within sequencing reads.  They are made up of a sequence of `<number><operator>` pairs.  Four kinds of operators are recognized:
+Read Structures are short strings that describe the origin and/or purpose of bases within sequencing reads.  They are made up of a sequence of `<number><operator>` pairs (segments).  Four kinds of operators are recognized:
 
 1. **T** identifies template reads/bases
 2. **B** identifies sample barcode reads/bases
@@ -158,6 +167,8 @@ One Read Structure must be provided for each input FASTQ file, in the same order
 ```shell
   --read-structures +T +T 8B 8B
 ```
+
+All sample barocde segments must be a fixed length.  E.g. `8B+T` is allowed but `10S+B` is not.
 
 ##### Sample Sheet
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ This repository is home to the `sgdemux` tool for demultiplexing sequencing data
 * [Usage](#usage)
   * [Inputs](#inputs)
     * [FASTQ Files](#fastq-files)
+      * [Auto-detecting FASTQS from a Path Prefix](#auto-detecting-fastqs-from-a-path-prefix)
     * [Read Structures](#read-structures)
     * [Sample Sheet](#sample-sheet)
       * [Specifying Demultiplexing Command Line Options](#specifying-demultiplexing-command-line-options)
@@ -125,6 +126,18 @@ for read in R1 R2 I1 I2; do cat L*/${read}.fastq.gz > ./${read}.fastq.gz; done
 ```
 
 FASTQ files _must_ be BGZF compressed.
+
+All reads containing sample barcodes/indexes _must_ be of the same length.
+
+###### Auto-detecting FASTQS from a Path Prefix
+
+Alternatively, the FASTQS can be auto-detected when a path prefix is given to `--fastqs <dir>/<prefix>`.
+The FASTQs must be named `<dir>/<prefix>_L00<lane>_<kind><kind-number>_001.fastq.gz`, where `kind` is
+one of R (read/template), I (index/sample barcode), or U (umi/molecular barcode). 
+
+If the read structure is given on the command line or Sample sheet, the segments are assumed to to
+apply to I1 R1 R2 I2 reads in that order.  Otherwise, the read structure will be `B+ T+ T+ B+` 
+(all index bases are used for the sample barcode, all read bases are assumed to be template).
 
 ##### Read Structures
 

--- a/src/lib/opts.rs
+++ b/src/lib/opts.rs
@@ -78,7 +78,7 @@ For support please contact: care@singulargenomics.com
 #[derive(Parser, Debug, Clone)]
 #[clap(name = TOOL_NAME, version = built_info::VERSION.as_str(), about=SHORT_USAGE, long_about=LONG_USAGE, term_width=0)]
 pub struct Opts {
-    /// Path to the input FASTQs.
+    /// Path to the input FASTQs or path prefix.
     #[clap(long, short = 'f', display_order = 1, required = true, multiple_values = true)]
     pub fastqs: Vec<PathBuf>,
 

--- a/src/lib/opts.rs
+++ b/src/lib/opts.rs
@@ -78,7 +78,7 @@ For support please contact: care@singulargenomics.com
 #[derive(Parser, Debug, Clone)]
 #[clap(name = TOOL_NAME, version = built_info::VERSION.as_str(), about=SHORT_USAGE, long_about=LONG_USAGE, term_width=0)]
 pub struct Opts {
-    /// Path to the input FASTQs or path prefix.
+    /// Path to the input FASTQs, or path prefix if not a file.
     #[clap(long, short = 'f', display_order = 1, required = true, multiple_values = true)]
     pub fastqs: Vec<PathBuf>,
 
@@ -86,7 +86,7 @@ pub struct Opts {
     #[structopt(long, short = 's', display_order = 2)]
     pub sample_metadata: PathBuf,
 
-    /// Read structures, one per input FASTQ.
+    /// Read structures, one per input FASTQ. Do not provide when using a path prefix for FASTQs.
     #[clap(long, short = 'r', display_order = 3, required = true, multiple_values = true)]
     pub read_structures: Vec<ReadStructure>,
 
@@ -279,7 +279,7 @@ impl Opts {
                 } else {
                     // Get the read length from the FASTQ, subtract all non variable length
                     // segments (must be a sample barcode if we've gone this far).
-                    let read_length: usize = infer_fastq_sequence_length(fastq.clone())?;
+                    let read_length: usize = infer_fastq_sequence_length(&fastq)?;
                     let fixed_length: usize =
                         read_structure.iter().map(|s| s.length().unwrap_or(0)).sum();
 
@@ -427,7 +427,6 @@ mod test {
             let data = format!("@NAME\n{}\n+\n{}\n", bases, quals);
             gz_writer.write_all(data.as_bytes()).unwrap();
             gz_writer.flush().unwrap();
-            drop(gz_writer);
         }
 
         // Create the opt, and update it

--- a/src/lib/opts.rs
+++ b/src/lib/opts.rs
@@ -90,7 +90,7 @@ pub struct Opts {
     #[clap(long, short = 'r', display_order = 3, required = true, multiple_values = true)]
     pub read_structures: Vec<ReadStructure>,
 
-    /// The directory to write outputs.
+    /// The directory to write outputs to.
     ///
     /// This tool will overwrite existing files.
     #[clap(long, short, display_order = 4)]

--- a/src/lib/run.rs
+++ b/src/lib/run.rs
@@ -88,7 +88,7 @@ pub fn run(opts: Opts) -> Result<(), anyhow::Error> {
     // expected length to enable index hopping metrics.  Do so by inspecting the first read in the
     // corresponding FASTQ
     // TODO: move to it's own method to test
-    let opts = opts.convert_to_fixed_sample_barcodes()?;
+    let opts = opts.with_fixed_sample_barcodes()?;
 
     // All sample barcode read segments should now have a fixed length, so check the sum of their
     // lengths with the sum of length of the sample barcode(s) in the sample sheet.

--- a/src/lib/run.rs
+++ b/src/lib/run.rs
@@ -477,6 +477,7 @@ mod test {
         run(opts).unwrap();
     }
 
+    /// Returns the character to use in the FASTQ file name for the given `SegmentType`.
     fn kind_to_char(kind: SegmentType) -> char {
         match kind {
             SegmentType::SampleBarcode => 'I',
@@ -487,6 +488,8 @@ mod test {
         }
     }
 
+    /// Creates the properly formatted FASZTQ file name to allow auto-detecting lane, kind, and
+    /// kind number from the file name.
     fn fastq_file_name(prefix: &str, lane: usize, kind: SegmentType, kind_number: usize) -> String {
         format!(
             "{}_L00{}_{}{}{}",

--- a/src/lib/run.rs
+++ b/src/lib/run.rs
@@ -87,7 +87,6 @@ pub fn run(opts: Opts) -> Result<(), anyhow::Error> {
     // If there is a read structure that's all sample barcode, we need to replace it with the
     // expected length to enable index hopping metrics.  Do so by inspecting the first read in the
     // corresponding FASTQ
-    // TODO: move to it's own method to test
     let opts = opts.with_fixed_sample_barcodes()?;
 
     // All sample barcode read segments should now have a fixed length, so check the sum of their

--- a/src/lib/run.rs
+++ b/src/lib/run.rs
@@ -487,7 +487,7 @@ mod test {
         }
     }
 
-    /// Creates the properly formatted FASZTQ file name to allow auto-detecting lane, kind, and
+    /// Creates the properly formatted FASTQ file name to allow auto-detecting lane, kind, and
     /// kind number from the file name.
     fn fastq_file_name(prefix: &str, lane: usize, kind: SegmentType, kind_number: usize) -> String {
         format!(

--- a/src/lib/run.rs
+++ b/src/lib/run.rs
@@ -114,7 +114,7 @@ pub fn run(opts: Opts) -> Result<()> {
         opts.read_structures
             .iter()
             .all(|s| s.sample_barcodes().all(read_structure::ReadSegment::has_length)),
-        "The Read Structure must have sample barcode segments with fixed lengths"
+        "Sample barcode segments in read structures must have fixed lengths."
     );
     ensure!(
         is_no_demux

--- a/src/lib/utils.rs
+++ b/src/lib/utils.rs
@@ -203,6 +203,20 @@ lazy_static! {
     static ref INPUT_FASTQ_REGEX: Regex = Regex::new(r"^(.*)_L00(\d)_([RIUS])(\d)_001.fastq.gz$").unwrap();
 }
 
+// Returns the character associated with the given `SegmentType` that should be used in a FASTQ file
+// name.
+pub fn segment_type_to_fastq_kind(segment_type: &SegmentType) -> char {
+    match segment_type {
+        SegmentType::Template => 'R',
+        SegmentType::SampleBarcode => 'I',
+        SegmentType::MolecularBarcode => 'U',
+        SegmentType::Skip => 'S',
+        knd => {
+            panic!("Unreachable - segment_type should enforce only [TSMB], found {}", knd.value())
+        }
+    }
+}
+
 /// Contains information about a FASTQ that has been inferred from the file name.  This includes
 /// lane, segment type (e.g. template/read, sample barcode/index, molecular barcode/index, and
 /// skip bases), and segment number (e.g. R1 or R2).

--- a/src/lib/utils.rs
+++ b/src/lib/utils.rs
@@ -373,7 +373,7 @@ pub fn infer_fastq_sequence_length(file: PathBuf) -> Result<usize, anyhow::Error
     match reader.next() {
         Some(Ok(record)) => Ok(record.seq().len()),
         _ => Err(anyhow!(
-            "Could determine sample barcode length from input FASTQ: {}",
+            "Could determine sample barcode length from empty input FASTQ: {}",
             file.to_string_lossy()
         )),
     }


### PR DESCRIPTION
The user may provide a path prefix (or directory) in which undetermined FASTQs live.  The file names are assumed to be of the form: `<*>_L00#_<R# or I#>_001.fastq.gz`.  The following can be inferred from this pattern: the lane number, read number, and if the FASTQ is a template or index read.

If no read structure is given either on the command line or Sample Sheet, then a new list of read structure is built, one per input FASTQ, where the _kind_ (segment type) is inferred from the file name and all bases are used.  E.g.
```
test_L001_I1.fastq.gz
test_L001_R1.fastq.gz
test_L001_R2.fastq.gz
test_L001_I2.fastq.gz
```
would yield the read structures `+B +T +T +B`.  Reads will all molecular barcodes are supported (e.g. `test_L001_U1.fastq.gz`) and bases to skip (e.g. `test_L001_S1.fastq.gz`).  The utility of the latter is questionable, but kept for completeness.

Improvement: due to the need for all sample barcode read segments to have a _fixed length_ (for index hopping metrics collection and some validation), the first read is read from each FASTQ that contains a variable length sample barcode to determine the read length and fix the length of the variable length sample barcode.  I don't believe that a read structure like `+B +T +T +B` previously worked!
