### PR TITLE
Handle when --fastqs is specified on the CLI while CLI options are also in a sample sheet

### DIFF
--- a/src/lib/opts.rs
+++ b/src/lib/opts.rs
@@ -90,8 +90,12 @@ For support please contact: care@singulargenomics.com
 #[derive(Parser, Debug, Clone)]
 #[clap(name = TOOL_NAME, version = built_info::VERSION.as_str(), about=SHORT_USAGE, long_about=LONG_USAGE, term_width=0)]
 pub struct Opts {
+    // NB: cannot set `required = True` for `fastqs` due to an issue with how clap updates
+    // the command line arguments when getting them from a sample sheet.  This occurs when
+    // trying to use the `try_update_from` on `Opts`.  A reproducible example independent
+    // of this code base can be found here: https://github.com/clap-rs/clap/issues/4617
     /// Path to the input FASTQs, or path prefix if not a file.
-    #[clap(long, short = 'f', display_order = 1, required = true, multiple_values = true)]
+    #[clap(long, short = 'f', display_order = 1, required = false, multiple_values = true)]
     pub fastqs: Vec<PathBuf>,
 
     /// Path to the sample metadata.

--- a/src/lib/opts.rs
+++ b/src/lib/opts.rs
@@ -93,7 +93,8 @@ pub struct Opts {
     // NB: cannot set `required = True` for `fastqs` due to an issue with how clap updates
     // the command line arguments when getting them from a sample sheet.  This occurs when
     // trying to use the `try_update_from` on `Opts`.  A reproducible example independent
-    // of this code base can be found here: https://github.com/clap-rs/clap/issues/4617
+    // of this code base can be found here: https://github.com/clap-rs/clap/issues/4617. The
+    // fix can be found here: https://github.com/clap-rs/clap/pull/4618.
     /// Path to the input FASTQs, or path prefix if not a file.
     #[clap(long, short = 'f', display_order = 1, required = false, multiple_values = true)]
     pub fastqs: Vec<PathBuf>,

--- a/src/lib/sample_metadata.rs
+++ b/src/lib/sample_metadata.rs
@@ -255,7 +255,11 @@ impl AsRef<SampleMetadata> for SampleMetadata {
 
 /// Validates a set of samples ([`SampleMetadata`] objects).
 ///
-/// If the `min_mismatch` is provided, the barcodes will be validated to ensure that there are no collisions.
+/// If the `min_mismatch` is provided, the barcodes will be validated to ensure that there are no
+/// collisions.
+///
+/// If there is more than one sample, or we have one sample with an actual barcode then add in
+/// an undetermined sample.
 ///
 /// # Errors
 ///

--- a/src/lib/sample_sheet.rs
+++ b/src/lib/sample_sheet.rs
@@ -477,6 +477,9 @@ mod test {
         assert_eq!(SampleSheet::find_section(&records, "[End]"), None);
     }
 
+    // TODO: uncomment when https://github.com/clap-rs/clap/pull/4618 is released and the clap
+    // dependency is updated
+    /*
     #[test]
     fn test_demux_missing_fastqs_and_read_structures() {
         // It's ok that we do not have any read structures, as it may be a path prefix.
@@ -501,6 +504,7 @@ mod test {
             assert_eq!(args, "--fastqs".to_string());
         }
     }
+    */
 
     #[test]
     fn test_demux_missing_read_structure() {
@@ -553,6 +557,21 @@ mod test {
         ];
 
         let opts = SampleSheet::parse_and_update_demux_options(&records, Opts::default()).unwrap();
+        assert_eq!(opts.fastqs, vec![PathBuf::from("/dev/null")]);
+        assert_eq!(opts.read_structures.iter().map(|r| format!("{}", r)).join(" "), "8B +T");
+        assert_eq!(opts.allowed_mismatches, 123);
+    }
+
+    #[test]
+    fn test_demux_existing_fastqs() {
+        // FASTQS is given on the command line, so already exists in Opts.  The sample sheet
+        // should parse just fine without it.
+        let opts = Opts { fastqs: vec![PathBuf::from("/dev/null")], ..Opts::default() };
+        let records: Vec<StringRecord> = vec![
+            StringRecord::from(vec!["read-structures", "8B +T"]),
+            StringRecord::from(vec!["allowed-mismatches", "123"]),
+        ];
+        let opts = SampleSheet::parse_and_update_demux_options(&records, opts).unwrap();
         assert_eq!(opts.fastqs, vec![PathBuf::from("/dev/null")]);
         assert_eq!(opts.read_structures.iter().map(|r| format!("{}", r)).join(" "), "8B +T");
         assert_eq!(opts.allowed_mismatches, 123);


### PR DESCRIPTION
Specifying `--fastqs` on the command line as well as other command line options in the sample sheet caused a Missing Argument error.  This is due to a bug in the option parsing library clap (see https://github.com/clap-rs/clap/issues/4617).  I added a comment to the code as such.  

The temporary solution is not to set _required_ for the FASTQs on the command line.  We validate that we have FASTQs elsewhere.  Once the fix in clap is released in https://github.com/clap-rs/clap/pull/4618, we can update our version of clap (which will likely require some other updates, since clap v3->v4 is a breaking API change) and set _required_ to true.