### PR TITLE
[feat] add an option to only process specific lanes

### DIFF
--- a/src/lib/demux.rs
+++ b/src/lib/demux.rs
@@ -451,11 +451,11 @@ where
 
             if !self.skip_read_name_check {
                 let first_head = zipped_reads[0].head();
-                let end_index = zipped_reads[0].head().find_byte(b' ').unwrap_or(first_head.len());
+                let end_index = zipped_reads[0].head().find_byte(b':').unwrap_or(first_head.len());
                 for read in zipped_reads.iter().dropping(1) {
                     let cur_head = read.head();
                     let ok = cur_head.len() == end_index
-                        || (cur_head.len() > end_index && cur_head[end_index] == b' ');
+                        || (cur_head.len() > end_index && cur_head[end_index] == b':');
                     let ok = ok && first_head[0..end_index] == cur_head[0..end_index];
                     ensure!(
                         ok,

--- a/src/lib/demux.rs
+++ b/src/lib/demux.rs
@@ -451,11 +451,11 @@ where
 
             if !self.skip_read_name_check {
                 let first_head = zipped_reads[0].head();
-                let end_index = zipped_reads[0].head().find_byte(b':').unwrap_or(first_head.len());
+                let end_index = zipped_reads[0].head().find_byte(b' ').unwrap_or(first_head.len());
                 for read in zipped_reads.iter().dropping(1) {
                     let cur_head = read.head();
                     let ok = cur_head.len() == end_index
-                        || (cur_head.len() > end_index && cur_head[end_index] == b':');
+                        || (cur_head.len() > end_index && cur_head[end_index] == b' ');
                     let ok = ok && first_head[0..end_index] == cur_head[0..end_index];
                     ensure!(
                         ok,

--- a/src/lib/run.rs
+++ b/src/lib/run.rs
@@ -124,7 +124,7 @@ pub fn run(opts: Opts) -> Result<()> {
     }
 
     info!(
-        "Creating writer threads (threads for writing/compressing: {}/{}",
+        "Creating writer threads (threads for writing/compressing: {}/{})",
         opts.writer_threads, opts.compressor_threads
     );
     let writers: Result<Vec<_>> = samples

--- a/src/lib/sample_sheet.rs
+++ b/src/lib/sample_sheet.rs
@@ -1,5 +1,6 @@
 use crate::opts::Opts;
 use crate::opts::TOOL_NAME;
+use crate::sample_metadata::coelesce_samples;
 use crate::sample_metadata::{validate_samples, SampleMetadata};
 use clap::Parser;
 use csv::{ReaderBuilder, StringRecord, Trim};
@@ -225,6 +226,7 @@ impl SampleSheet {
             samples.push(record);
         }
 
+        let samples = coelesce_samples(samples, &opts.lane);
         let samples = validate_samples(
             samples,
             Some(opts.allowed_mismatches),
@@ -407,6 +409,7 @@ impl SampleSheet {
         };
 
         let samples = SampleSheet::slurp_samples(&records[start..=end], start)?;
+        let samples = coelesce_samples(samples, &opts.lane);
 
         // Validate the samples
         let samples = validate_samples(

--- a/src/lib/sample_sheet.rs
+++ b/src/lib/sample_sheet.rs
@@ -429,7 +429,7 @@ mod test {
     use crate::opts::Opts;
     use crate::sample_sheet::{SampleSheet, SampleSheetError};
     use bstr::BString;
-    use clap::error::ErrorKind::{MissingRequiredArgument, UnknownArgument};
+    use clap::error::ErrorKind::UnknownArgument;
     use csv::StringRecord;
     use itertools::Itertools;
     use matches::assert_matches;
@@ -598,11 +598,11 @@ mod test {
         assert_eq!(samples[0].sample_id, "S1");
         assert_eq!(samples[0].index1, Some(BString::from("AAAA")));
         assert_eq!(samples[0].index2, Some(BString::from("CCCC")));
-        assert_eq!(samples[0].ordinal, 1);
+        assert_eq!(samples[0].ordinal, 0);
         assert_eq!(samples[1].sample_id, "S2");
         assert_eq!(samples[1].index1, Some(BString::from("GGGG")));
         assert_eq!(samples[1].index2, Some(BString::from("TTTT")));
-        assert_eq!(samples[1].ordinal, 2);
+        assert_eq!(samples[1].ordinal, 1);
     }
 
     #[test]

--- a/src/lib/sample_sheet.rs
+++ b/src/lib/sample_sheet.rs
@@ -344,7 +344,7 @@ impl SampleSheet {
         let header = &records[0];
 
         // parse the samples
-        let mut ordinal = 1;
+        let mut ordinal = 0;
         let mut samples: Vec<SampleMetadata> = vec![];
         for record in &records[1..] {
             // allow an empty line


### PR DESCRIPTION
Only samples (in the sample sheet) and FASTQs (with known lane numbers) will be processed that match the provided list of lanes.  This option cannot be used when the lane for a FASTQ is not known (e.g. when the FASTQS are explicitly given on the command line).

Also allow the same sample_id/barcode combination is used across lanes for a given sample.  Previously an error would occur, now the repeated sample is treated as one sample (just in many lanes).

Other changes:
- the read name is only checked up to the first colon within a group of FASTQS (e.g. R1 across lanes)
- print out the # of threads being used