### PR TITLE
[feat] use lane from sample metadata in filename or --lanes

### DIFF
--- a/src/lib/sample_metadata.rs
+++ b/src/lib/sample_metadata.rs
@@ -345,7 +345,12 @@ pub fn coelesce_samples(samples: Vec<SampleMetadata>, lanes: &[usize]) -> Vec<Sa
         .into_iter()
         .map(|(_, group)| {
             let sample = group[0].clone();
-            SampleMetadata { lane: None, ..sample }
+            if group.len() > 1 {
+                // only remove lane information if there was > 1 sample found
+                SampleMetadata { lane: None, ..sample }
+            } else {
+                sample
+            }
         })
         .collect();
 

--- a/src/lib/utils.rs
+++ b/src/lib/utils.rs
@@ -72,7 +72,7 @@ pub fn filename(sample: &SampleMetadata, kind: &SegmentType, type_number: u32) -
         "{}_S{}_L00{}_{}{}_001.fastq.gz",
         sample.sample_id,
         sample.ordinal + 1,
-        1,
+        sample.lane.unwrap_or(1),
         segment_kind_to_fastq_id(kind),
         type_number
     )


### PR DESCRIPTION
If the same sample is specified across lanes, then no lane (lane 1 default) will be used in the output file name.