### PR TITLE
[feat] allow the auto-detected read structure to be overriden

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ Furthermore, multiple lanes may be given and will be used for demultiplexing:
 
 When data for multiple lanes is provided, each lane must have the same number and types of input fastqs.
 
-The auto-detected/derived Read Structure may be override on the command line or in the sample sheet
+The auto-detected/derived Read Structure may be overriden on the command line or in the sample sheet
 by providing the `--read-structures` argument.  In this case, the new read structure must be given
 and will be applied in the same order as described above (e.g. I1, I2, R1, R2 for a dual index paired end run).
 

--- a/README.md
+++ b/README.md
@@ -134,8 +134,7 @@ Alternatively, the FASTQS can be auto-detected when a path prefix is given to `-
 The FASTQs must be named `<dir>/<prefix>_L00<lane>_<kind><kind-number>_001.fastq.gz`, where `kind` is
 one of R (read/template), I (index/sample barcode), or U (umi/molecular barcode). 
 
-The Read Structure must not be given on the the command line or Sample Sheet.  Instead, the Read 
-Structure will be derived from file names (kind and kind number), with the full read length used for the given kind.
+The Read Structure will be derived from file names (kind and kind number), with the full read length used for the given kind.
 The derived Read Structure and FASTQs will be ordered first by `kind` (I then R then U), second by
 read number (e.g. R1 before R2).  This is important for command line options that can be specified once per read kind and number.
  E.g. if the following FASTQs are present with path prefix `/path/to/prefix`:
@@ -165,6 +164,10 @@ Furthermore, multiple lanes may be given and will be used for demultiplexing:
 ```
 
 When data for multiple lanes is provided, each lane must have the same number and types of input fastqs.
+
+The auto-detected/derived Read Structure may be override on the command line or in the sample sheet
+by providing the `--read-structures` argument.  In this case, the new read structure must be given
+and will be applied in the same order as described above (e.g. I1, I2, R1, R2 for a dual index paired end run).
 
 #### Read Structures
 

--- a/src/lib/matcher.rs
+++ b/src/lib/matcher.rs
@@ -331,8 +331,6 @@ fn hamming_distance(alpha: &[u8], beta: &[u8], free_ns: usize) -> usize {
 
 #[cfg(test)]
 mod test {
-    use std::array::IntoIter;
-
     use ahash::AHashMap;
     use bstr::{BString, B};
 
@@ -405,7 +403,7 @@ mod test {
         let max_mismatches = 1;
         let min_delta = 2;
 
-        let expected = AHashMap::from_iter(IntoIter::new([
+        let expected = AHashMap::from_iter(IntoIterator::into_iter([
             (B("AAG").to_vec(), PrecomputedMatch { sample: 0, hamming_dist: 1 }),
             (B("AGA").to_vec(), PrecomputedMatch { sample: 0, hamming_dist: 1 }),
             (B("GAA").to_vec(), PrecomputedMatch { sample: 0, hamming_dist: 1 }),

--- a/src/lib/opts.rs
+++ b/src/lib/opts.rs
@@ -319,7 +319,7 @@ impl Opts {
             }
 
             // If read structures are given on the command line or in the sample sheet, then
-            // replaces the existing read structures.  The number of FASTQ groups must match the
+            // replace the existing read structures.  The number of FASTQ groups must match the
             // number of provided read structures; order matters in the replacement.
             let input_fastq_group = if read_structures.is_empty() {
                 input_fastq_group

--- a/src/lib/opts.rs
+++ b/src/lib/opts.rs
@@ -917,23 +917,6 @@ mod test {
     }
 
     #[test]
-    fn test_opts_from_error_read_structures_with_prefix() {
-        let dir = tempdir().unwrap();
-        let prefix = dir.path().join("prefix");
-        let opts = Opts {
-            read_structures: vec![ReadStructure::from_str("+B").unwrap()],
-            fastqs: vec![prefix],
-            ..Opts::default()
-        };
-
-        let result = Opts::from(&opts.fastqs, &opts.read_structures, false, &vec![]);
-        assert!(result.is_err());
-        if let Err(error) = result {
-            assert!(error.to_string().contains("Read Structure must not be given"));
-        }
-    }
-
-    #[test]
     fn test_opts_from_error_no_fastqs_found_with_prefix() {
         let dir = tempdir().unwrap();
         let prefix = dir.path().join("prefix");


### PR DESCRIPTION
When the user provides a FASTQ prefix to search for FASTQs, the read structure is derived from the file names (see the README).  This PR gives the ability to the user to override the derieved/auto-detected read structures and replace with a user provided one.  

For example, the read names are I1, I2, R1, and R2, then the derived read structure is `+B +B +T +T`. But if there are UMI bases in I1, then the read structure can be overridden by specifying `--read-structures 4M+B +B +T +T` on the command line (or `read-structures,4M+B +B +T +T` in the `Demux` section of the sample sheet.