### PR TITLE
Bugfix/specify lane ordinal sorting

### DIFF
--- a/src/lib/run.rs
+++ b/src/lib/run.rs
@@ -47,8 +47,8 @@ pub fn run(opts: Opts) -> Result<()> {
 
     // Print some information about the read structures and associated FASTQs
     let read_structure_str: String =
-        input_fastq_groups.iter().map(|g| format!(" {}", g.read_structure)).into_iter().collect();
-    info!("Using read structures:{}", read_structure_str);
+        input_fastq_groups.iter().map(|g| format!("{}", g.read_structure)).join(" ");
+    info!("Using read structures: {}", read_structure_str);
     for input_fastq_group in &input_fastq_groups {
         info!("  Read structure: {}", input_fastq_group.read_structure);
         info!("  FASTQs:");

--- a/src/lib/sample_metadata.rs
+++ b/src/lib/sample_metadata.rs
@@ -268,6 +268,8 @@ impl AsRef<SampleMetadata> for SampleMetadata {
 ///
 /// # Errors
 ///
+/// - [`SampleSheetError::ZeroSamples`]
+/// - [`SampleSheetError::ZeroSamplesForLane`]
 /// - [`SampleSheetError::DuplicateSampleId`]
 /// - [`SampleSheetError::InvalidBarcode`]
 /// - [`SampleSheetError::BarcodeCollision`]
@@ -276,9 +278,14 @@ pub fn validate_samples(
     mut samples: Vec<SampleMetadata>,
     min_mismatch: Option<usize>,
     undetermined_name: &str,
+    lanes: &[usize],
 ) -> Result<Vec<SampleMetadata>, SampleSheetError> {
     if samples.is_empty() {
-        return Err(SampleSheetError::ZeroSamples);
+        if lanes.is_empty() {
+            return Err(SampleSheetError::ZeroSamples);
+        }
+        let lanes_str = lanes.iter().map(|lane| format!("{}", lane)).join(",");
+        return Err(SampleSheetError::ZeroSamplesForLane { lanes: lanes_str });
     }
 
     // Check for duplicate sample identifiers

--- a/src/lib/sample_metadata.rs
+++ b/src/lib/sample_metadata.rs
@@ -324,7 +324,7 @@ pub fn validate_samples(
         // If we have more than one sample, or we have one sample with an actual barcode
         // then add in the undetermined sample.  The ordinal must be larger than the maximum
         // ordinal of an existing sample.
-        let undetermined_ordinal = samples.iter().map(|s| s.ordinal).max().unwrap() + 1;
+        let undetermined_ordinal = prev_ordinal + 1;
         samples.push(SampleMetadata::new_allow_invalid_bases(
             String::from(undetermined_name),
             BString::from(vec![b'N'; samples[0].barcode.len()]),

--- a/src/lib/sample_sheet.rs
+++ b/src/lib/sample_sheet.rs
@@ -120,6 +120,9 @@ pub enum SampleSheetError {
 
     #[error("Sample metadata must include at least one sample")]
     ZeroSamples,
+
+    #[error("Sample metadata must include at least one sample for lane(s): {lanes}")]
+    ZeroSamplesForLane { lanes: String },
 }
 
 #[derive(Debug, Clone)]
@@ -238,6 +241,7 @@ impl SampleSheet {
             samples,
             Some(opts.allowed_mismatches),
             &opts.undetermined_sample_name,
+            &opts.lane,
         )?;
 
         Ok(SampleSheet { samples, opts })
@@ -427,6 +431,7 @@ impl SampleSheet {
             samples,
             Some(opts.allowed_mismatches),
             &opts.undetermined_sample_name,
+            &opts.lane,
         )?;
 
         Ok(SampleSheet { samples, opts })

--- a/src/lib/sample_sheet.rs
+++ b/src/lib/sample_sheet.rs
@@ -234,7 +234,7 @@ impl SampleSheet {
 
         let samples = coelesce_samples(samples, &opts.lane)
             .iter()
-            .sorted_by(|a, b| a.ordinal.cmp(&b.ordinal))
+            .sorted_by_key(|a| a.ordinal)
             .cloned()
             .collect();
         let samples = validate_samples(


### PR DESCRIPTION
 [bugfix] reads were written to the wrong file when --lanes was used
    
When subsetting to a specific lane, the reads were being written to the
wrong output file.  This was caused by the list of samples internally
not being in ascending order by ordinal, but the writers created after
sorting the samples by ordinal.
    
The fix is to order the samples by ordinal prior to creating the
writers, and adding in validation code to ensure the samples are sorted
in ascending order by ordinal.
    
Also changed the ordinal of the undetermined sample to be one larger
than the largest ordinal in the existing samples.