### PR TITLE
Unit tests and fixes to Matchers

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,22 +86,22 @@ Note: the allowed mismatches is not used when determining the next-best matching
 For additional examples, consider `--allowed-mismatches 3 --min-delta 1`, with two barcodes `b1` and `b2`:
 
 1. If b1 matches with 2 mismatches, and b2 matches with 3 mismatches, then the delta between the number of mismatches is 1, which _is not_ greater than `--min-delta`, and therefore the read is not assigned to a barcode.
-2. If b1 matches with 1 mismatch, and b2 matches with 3 mismatches, then the delta between the number of mismatches is 2, which _is_ greater than `--min-delta`, and therefore the read is assigned to barcode `b1`.
-3. If b1 matches with 0 mismatch, and b2 matches with 2 mismatches, then the delta between the number of mismatches is 2, which _is_ greater than `--min-delta`, and therefore the read is assigned to barcode `b1`.
-4. If b1 matches with 0 mismatches, and b2 matches with 1 mismatches, then the delta between the number of mismatches is 1, which _is not_ greater than `--min-delta`, and therefore the read is not assigned to a barcode.
-5. If b1 matches with 3 mismatches, and b2 matches with 6 mismatches, then the delta between the number of mismatches is 2, which _is_ greater than `--min-delta`, and the number of mismatches for b1 is less than equal to than `--allowed-mismatches`, and thefore read is assigned to barcode `b1`.
-6. If b1 matches with 4 mismatches, and b2 matches with 6 mismatches, then the delta between the number of mismatches is 2, which _is_ greater than `--min-delta`, and but the number of mismatches for b1 is greater than `--allowed-mismatches`, and thefore the read is not assigned to a barcode.
-7. If b1 matches with 2 mismatch, and b2 matches with 2 mismatches, then the delta between the number of mismatches is 0, which _is not_ greater than `--min-delta`, and therefore the read is not assigned to a
+1. If b1 matches with 1 mismatch, and b2 matches with 3 mismatches, then the delta between the number of mismatches is 2, which _is_ greater than `--min-delta`, and therefore the read is assigned to barcode `b1`.
+1. If b1 matches with 0 mismatch, and b2 matches with 2 mismatches, then the delta between the number of mismatches is 2, which _is_ greater than `--min-delta`, and therefore the read is assigned to barcode `b1`.
+1. If b1 matches with 0 mismatches, and b2 matches with 1 mismatches, then the delta between the number of mismatches is 1, which _is not_ greater than `--min-delta`, and therefore the read is not assigned to a barcode.
+1. If b1 matches with 3 mismatches, and b2 matches with 6 mismatches, then the delta between the number of mismatches is 3, which _is_ greater than `--min-delta`, and the number of mismatches for b1 is less than equal to than `--allowed-mismatches`, and thefore read is assigned to barcode `b1`.
+1. If b1 matches with 4 mismatches, and b2 matches with 6 mismatches, then the delta between the number of mismatches is 2, which _is_ greater than `--min-delta`, but the number of mismatches for b1 is greater than `--allowed-mismatches`, and thefore the read is not assigned to a barcode.
+1. If b1 matches with 2 mismatch, and b2 matches with 2 mismatches, then the delta between the number of mismatches is 0, which _is not_ greater than `--min-delta`, and therefore the read is not assigned to a
 barcode.
 
 Several other options affect how demultiplexing is performed, and for these to be fully understood it is necessary to understand the order in which they are applied in the demultiplexing process.  Operations are ordered as follows:
 
 1. A record is read in from each of the input FASTQ files and broken into read "segments" using the supplied read structures.
-2. If `--filter-control-reads` is specified and the reads are marked as controls in the FASTQ header, the reads are discarded (i.e. they do not get written to _any_ output files).
-3. If `--filter-failing-quality` is specified and the reads are marked as quality failures in the FASTQ header, the reads are discarded (i.e. they do not get written to _any_ output files).
-4. If one or more `--quality-mask-threshold` values are supplied, template bases in all input reads that have base quality below the given threshold value are masked to `N`.
-5. Match the reads against the set of expected barcodes; if the sample barcode has more `N` bases in it that specified by `--max-no-calls` or does not match to an expected barcode within defined parameters, the reads will be assigned to the undetermined sample.
-6. Write out the subset of the FASTQs/read segments specified by `--output-types` to the FASTQ file(s) for the assigned sample.
+1. If `--filter-control-reads` is specified and the reads are marked as controls in the FASTQ header, the reads are discarded (i.e. they do not get written to _any_ output files).
+1. If `--filter-failing-quality` is specified and the reads are marked as quality failures in the FASTQ header, the reads are discarded (i.e. they do not get written to _any_ output files).
+1. If one or more `--quality-mask-threshold` values are supplied, template bases in all input reads that have base quality below the given threshold value are masked to `N`.
+1. Match the reads against the set of expected barcodes; if the sample barcode has more `N` bases in it that specified by `--max-no-calls` or does not match to an expected barcode within defined parameters, the reads will be assigned to the undetermined sample.
+1. Write out the subset of the FASTQs/read segments specified by `--output-types` to the FASTQ file(s) for the assigned sample.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -57,16 +57,16 @@ Install from pre-built binaries on the [Releases page][releases]
 2. Install dependencies. For example, cmake and build-essentials are required for Ubuntu 22.04. Install using commands below.
 
 ```console
-sudo apt-get update 
+sudo apt-get update
 sudo apt-get install build-essential cmake -y
 ```
-Note: cmake for older OS version such as Ubuntu 18.04 is not incompatible.   
+Note: cmake for older OS version such as Ubuntu 18.04 is not incompatible.
 
 3. Clone the repo and build the software:
 
 ```console
 git clone https://github.com/Singular-Genomics/singular-demux.git
-cd singular-demux 
+cd singular-demux
 cargo install --path ../singular-demux --locked
 ```
 
@@ -86,12 +86,13 @@ Note: the allowed mismatches is not used when determining the next-best matching
 For additional examples, consider `--allowed-mismatches 3 --min-delta 1`, with two barcodes `b1` and `b2`:
 
 1. If b1 matches with 2 mismatches, and b2 matches with 3 mismatches, then the delta between the number of mismatches is 1, which _is not_ greater than `--min-delta`, and therefore the read is not assigned to a barcode.
-1. If b1 matches with 1 mismatch, and b2 matches with 3 mismatches, then the delta between the number of mismatches is 2, which _is_ greater than `--min-delta`, and therefore the read is assigned to barcode `b1`.
-1. If b1 matches with 2 mismatch, and b2 matches with 2 mismatches, then the delta between the number of mismatches is 2, which _is_ greater than `--min-delta`, and therefore the read is assigned to barcode `b1`.
-1. If b1 matches with 0 mismatches, and b2 matches with 1 mismatches, then the delta between the number of mismatches is 1, which _is not_ greater than `--min-delta`, and therefore the read is not assigned to a barcode.
-1. If b1 matches with 3 mismatches, and b2 matches with 6 mismatches, then the delta between the number of mismatches is 2, which _is_ greater than `--min-delta`, and the number of mismatches for b1 is less than equal to than `--allowed-mismatches`, and thefore read is assigned to barcode `b1`.
-1. If b1 matches with 4 mismatches, and b2 matches with 6 mismatches, then the delta between the number of mismatches is 2, which _is_ greater than `--min-delta`, and but the number of mismatches for b1 is greater than `--allowed-mismatches`, and thefore the read is not assigned to a barcode.
-
+2. If b1 matches with 1 mismatch, and b2 matches with 3 mismatches, then the delta between the number of mismatches is 2, which _is_ greater than `--min-delta`, and therefore the read is assigned to barcode `b1`.
+3. If b1 matches with 0 mismatch, and b2 matches with 2 mismatches, then the delta between the number of mismatches is 2, which _is_ greater than `--min-delta`, and therefore the read is assigned to barcode `b1`.
+4. If b1 matches with 0 mismatches, and b2 matches with 1 mismatches, then the delta between the number of mismatches is 1, which _is not_ greater than `--min-delta`, and therefore the read is not assigned to a barcode.
+5. If b1 matches with 3 mismatches, and b2 matches with 6 mismatches, then the delta between the number of mismatches is 2, which _is_ greater than `--min-delta`, and the number of mismatches for b1 is less than equal to than `--allowed-mismatches`, and thefore read is assigned to barcode `b1`.
+6. If b1 matches with 4 mismatches, and b2 matches with 6 mismatches, then the delta between the number of mismatches is 2, which _is_ greater than `--min-delta`, and but the number of mismatches for b1 is greater than `--allowed-mismatches`, and thefore the read is not assigned to a barcode.
+7. If b1 matches with 2 mismatch, and b2 matches with 2 mismatches, then the delta between the number of mismatches is 0, which _is not_ greater than `--min-delta`, and therefore the read is not assigned to a
+barcode.
 
 Several other options affect how demultiplexing is performed, and for these to be fully understood it is necessary to understand the order in which they are applied in the demultiplexing process.  Operations are ordered as follows:
 
@@ -146,7 +147,7 @@ FASTQ files _must_ be BGZF compressed.
 
 Alternatively, the FASTQS can be auto-detected when a path prefix is given to `--fastqs <dir>/<prefix>`.
 The FASTQs must be named `<dir>/<prefix>_L00<lane>_<kind><kind-number>_001.fastq.gz`, where `kind` is
-one of R (read/template), I (index/sample barcode), or U (umi/molecular barcode). 
+one of R (read/template), I (index/sample barcode), or U (umi/molecular barcode).
 
 The Read Structure will be derived from file names (kind and kind number), with the full read length used for the given kind.
 The derived Read Structure and FASTQs will be ordered first by `kind` (I then R then U), second by
@@ -193,7 +194,7 @@ Read Structures are short strings that describe the origin and/or purpose of bas
 4. **S** identifies a set of bases to be skipped or ignored
 
 The last `<number><operator>` pair in a Read Structure may use `+` instead of a number to denote "all remaining bases".
-This is useful if, e.g., FASTQs have been trimmed and/or contain reads of varying length. 
+This is useful if, e.g., FASTQs have been trimmed and/or contain reads of varying length.
 
 For more details on Read Structures, and how to validate them, see [this detailed description](https://github.com/fulcrumgenomics/fgbio/wiki/Read-Structures).
 
@@ -214,14 +215,14 @@ The sample metadata file may be a Sample Sheet or a simple two-column CSV file w
 
 ##### Sample Sheet
 
-Information about the sample(s) to demultiplex is specified within a Sample Sheet. 
+Information about the sample(s) to demultiplex is specified within a Sample Sheet.
 Command line options for demultiplexing may also be passed via the Sample Sheet.
 
 The Sample Sheet may have a `[Demux]` section for command line options, and must have a `[Data]`
-section for sample information.  
+section for sample information.
 
 The `[Demux]` section must contain a line per command line option.
-The first column must contain the option long name _without_ the leading `--` (e.g. `fastqs` or 
+The first column must contain the option long name _without_ the leading `--` (e.g. `fastqs` or
 `read-structures`).
 The second column contains the option value, or empty if the option takes no value (i.e. a flag).
 If the option accepts multiple values, they must be space separated in the second column.
@@ -231,7 +232,7 @@ The order of the FASTQs must match the order read structures.
 The `[Data]` section must contain a header line.
 The `Sample_ID` column must contain a unique, non-empty identifier
 for each sample.  One or both of `Index1_Sequence` and `Index2_Sequence` must be present with values for
-indexed runs.  For non-indexed runs, a single sample must be given with an empty value for both the 
+indexed runs.  For non-indexed runs, a single sample must be given with an empty value for both the
 `Index1_Sequence` and `Index2_Sequence` columns.
 Both `Sample_ID`s and the `Index1_Sequence`/`Index2_Sequence` combinations must be unique within the file, and both columns are required for all samples.
 
@@ -245,7 +246,7 @@ read-structures,+B +T
 Sample_ID,Index1_Sequence,Index2_Sequence
 s1,ACTGGTCA,
 s2,ATACGAAC,
-``` 
+```
 
 ##### Simple Two-column CSV
 
@@ -259,7 +260,7 @@ An example follows:
 Sample_ID,Sample_Barcode
 s1,ACTGGTCA
 s2,ATACGAAC
-``` 
+```
 
 For example if a dual-indexing run was performed with an additional inline sample barcode in read 1, and `sgdemux` was invoked with the following options:
 
@@ -360,7 +361,7 @@ The `per_project_metrics.tsv` file aggregates the metrics by project (aggregates
 samples with the same project) and has the same columns as [per_sample_metrics.tsv](#per_sample_metricstsv).
 In this case, `barcode_name` and `library_name` will contain the project name (or `None` if no
 project is given).
-THe `barcode` will contain all `N`s. 
+THe `barcode` will contain all `N`s.
 The undetermined sample will not be aggregated with any other sample.
 
 ##### `metrics.tsv`

--- a/src/lib/matcher.rs
+++ b/src/lib/matcher.rs
@@ -192,13 +192,15 @@ impl<'a> PreComputeMatcher<'a> {
 
     /// Generate all permutations of a string between min and max mismatches inclusive
     fn all_permutations(
-        barcode: &'_ [u8],
+        barcode: &[u8],
         min_mismatches: usize,
         max_mismatches: usize,
-    ) -> impl Iterator<Item = (Vec<u8>, usize)> + '_ {
+    ) -> impl Iterator<Item = (Vec<u8>, usize)> {
         let free_ns = 0;
+        // xs.iter().combinations(n) returns [] if n > xs.len();
+        let max_mismatches = max_mismatches.min(barcode.len());
         (0..barcode.len())
-            .combinations(max_mismatches)
+            .combinations(max_mismatches) // generate positions to insert mismatches
             .flat_map(move |locations| {
                 let mut this_barcode = barcode.iter().map(|c| vec![*c]).collect::<Vec<Vec<u8>>>();
                 for location in locations {
@@ -247,7 +249,7 @@ impl<'a> PreComputeMatcher<'a> {
                 let best = best_hits[0];
                 if matches
                     .iter()
-                    .filter(|m| m.hamming_dist <= best.hamming_dist + min_delta)
+                    .filter(|m| should_reject_delta(m.hamming_dist - best.hamming_dist, min_delta))
                     .count()
                     == 1
                 {
@@ -257,6 +259,13 @@ impl<'a> PreComputeMatcher<'a> {
         }
         None
     }
+}
+
+#[inline]
+fn should_reject_delta(delta: usize, min_delta: usize) -> bool {
+    // Delta is the difference best distance and next best distance.
+    // Accept delta > min_delta and reject delta <=  min_delta
+    delta <= min_delta
 }
 
 /// Finds the best barcode barcode-by-barcode
@@ -284,7 +293,7 @@ fn find_independently(
     }
     if best_sample == samples.len()
         || best_dist > max_mismatches
-        || next_best_dist - best_dist < min_delta
+        || should_reject_delta(next_best_dist - best_dist, min_delta)
     {
         MatchResult::NoMatch { barcode }
     } else {
@@ -434,6 +443,11 @@ mod test {
 
         let found = PreComputeMatcher::build_map(&samples, max_mismatches, min_delta);
         assert_eq!(expected, found);
+
+        // Check degenerate case (possible in tests) where permutations work with max_matches > barcode len
+        let l = PreComputeMatcher::build_map(&samples, 3, 0);
+        let r = PreComputeMatcher::build_map(&samples, 10, 0);
+        assert_eq!(l, r);
     }
 
     #[test]
@@ -484,13 +498,25 @@ mod test {
 
 #[cfg(test)]
 mod test_matches {
-    use super::{find_independently, hamming_distance, MatchResult, Matcher, PreComputeMatcher};
     use crate::sample_metadata::SampleMetadata;
 
     use super::test::create_sample;
+    use super::{
+        find_independently, hamming_distance, should_reject_delta, MatchResult, Matcher,
+        PreComputeMatcher,
+    };
 
     pub(super) fn create_samples(barcodes: &[&str]) -> Vec<SampleMetadata> {
-        barcodes.iter().map(|b| create_sample(bstr::BString::from(b.clone()))).collect()
+        // need unique ordinals for appropriate test output from PreComputeMatcher::build_map
+        barcodes
+            .into_iter()
+            .enumerate()
+            .map(|(i, b)| {
+                let mut s = create_sample(bstr::BString::from(b.clone()));
+                s.ordinal = i;
+                s
+            })
+            .collect()
     }
 
     // Helper fun to make find_independent call more concise
@@ -501,6 +527,23 @@ mod test_matches {
         min_delta: usize,
     ) -> MatchResult {
         find_independently(barcode, samples, max_mismatches, min_delta, 0, hamming_distance)
+    }
+
+    // A really pedantic test because prior impls had a bug.
+    #[test]
+    fn test_reject_delta() {
+        // e.g.) min_delta == 0 is the most permissive setting.
+        // When min_delta == 0:
+        //  if delta <= 0, reject
+        //  if delta > 0 (i.e. >= 1), accept
+        assert!(should_reject_delta(0, 0)); // reject
+        assert!(!should_reject_delta(1, 0)); // accept
+        assert!(!should_reject_delta(2, 0));
+
+        // min_delta == 3
+        assert!(should_reject_delta(1, 3)); // reject
+        assert!(should_reject_delta(3, 3)); // reject
+        assert!(!should_reject_delta(4, 3)); // accept
     }
 
     #[test]
@@ -580,12 +623,12 @@ mod test_matches {
 
 #[cfg(test)]
 mod test_readme_examples {
-    use super::{hamming_distance, Matcher, PreComputeMatcher};
     use crate::sample_metadata::SampleMetadata;
 
     use super::test_matches::{create_samples, find_ind};
+    use super::{hamming_distance, Matcher, PreComputeMatcher};
 
-    struct TestConfig {
+    struct SimpleTest {
         should_match: bool,
         max_mismatches: usize,
         min_delta: usize,
@@ -593,54 +636,57 @@ mod test_readme_examples {
         b2_dist: usize,
     }
 
-    fn test_w_config(c: TestConfig) {
-        assert!(c.b2_dist >= c.b1_dist);
-        // Guarantee that barcodes are max_dist apart.
-        let sample_b1 = "A".repeat(c.b2_dist * 2);
-        let mut sample_b2 = "C".repeat(c.b2_dist);
-        sample_b2.push_str(&"A".repeat(c.b2_dist));
+    impl SimpleTest {
+        fn run(self) {
+            assert!(self.b2_dist >= self.b1_dist);
 
-        let samples: Vec<SampleMetadata> = create_samples(&[&sample_b1, &sample_b2]);
+            // generate some barcodes
+            let sample_b1 = "A".repeat(self.b2_dist);
+            let sample_b2 = "T".repeat(self.b2_dist);
 
-        let mut observed_barcode = vec![b'G'; c.b1_dist];
-        observed_barcode.append(&mut vec![b'A'; sample_b1.len() - c.b1_dist]);
+            let samples: Vec<SampleMetadata> = create_samples(&[&sample_b1, &sample_b2]);
 
-        let ind_result =
-            find_ind(observed_barcode.clone(), &samples, c.max_mismatches, c.min_delta);
-        let matcher = PreComputeMatcher::new(&samples, c.max_mismatches, c.min_delta, 0);
-        let pc_result = matcher.find(observed_barcode.clone());
+            let mut observed_barcode = vec![b'G'; self.b1_dist];
+            observed_barcode.append(&mut vec![b'A'; sample_b1.len() - self.b1_dist]);
 
-        // check that the generated observed barcode has given distances.
-        assert_eq!(hamming_distance(&observed_barcode, sample_b1.as_bytes(), 0), c.b1_dist);
-        assert_eq!(hamming_distance(&observed_barcode, sample_b2.as_bytes(), 0), c.b2_dist);
+            let ind_result =
+                find_ind(observed_barcode.clone(), &samples, self.max_mismatches, self.min_delta);
+            let matcher = PreComputeMatcher::new(&samples, self.max_mismatches, self.min_delta, 0);
+            let pc_result = matcher.find(observed_barcode.clone());
 
-        dbg!(sample_b1);
-        dbg!(sample_b2);
-        dbg!(String::from_utf8(observed_barcode).unwrap());
+            // check that the generated observed barcode has given distances.
+            assert_eq!(hamming_distance(&observed_barcode, sample_b1.as_bytes(), 0), self.b1_dist);
+            assert_eq!(hamming_distance(&observed_barcode, sample_b2.as_bytes(), 0), self.b2_dist);
 
-        if c.should_match {
-            assert!(ind_result.is_match(), "independent matcher failed to find match");
-            assert!(
-                pc_result.is_match(),
-                "independent matcher found match but precompute matcher failed to find match"
-            );
-        } else {
-            assert!(ind_result.is_no_match(), "independent matcher failed to reject match");
-            assert!(
+            dbg!(sample_b1);
+            dbg!(sample_b2);
+            dbg!(String::from_utf8(observed_barcode).unwrap());
+
+            if self.should_match {
+                assert!(ind_result.is_match(), "independent matcher failed to find match");
+                assert!(
+                    pc_result.is_match(),
+                    "independent matcher found match but precompute matcher failed to find match"
+                );
+            } else {
+                assert!(ind_result.is_no_match(), "independent matcher failed to reject match");
+                assert!(
                 pc_result.is_no_match(),
                 "independent matcher rejected match but precompute matcher failed to reject match"
             );
+            }
         }
     }
 
     fn test_readme_ex(should_match: bool, best_dist: usize, next_dist: usize) {
-        test_w_config(TestConfig {
+        SimpleTest {
             should_match,
             max_mismatches: 3,
             min_delta: 1,
             b1_dist: best_dist,
             b2_dist: next_dist,
-        });
+        }
+        .run();
     }
 
     #[test]


### PR DESCRIPTION
**README changes**
- added: example with equal best and second best matches
- fix: README example 3 w/ best and second best match distances 0 and 2, respectively
- fix: Whitespace and bullets in README

**Fixes**
- Refactored `should_reject_delta` so all logic is in one place
- The condition for rejection should have been `delta <= min_delta`. In English, we accept matches if delta is strictly greater than `delta`. An illustrative example is with `min_delta == 0`, the most permissive setting. When `min_delta == 0`, we accept all deltas > `0`. Note that `delta == 0` iff there are multiple best matches, and that `delta == usize::MAX` when there is only one match and that match is unique (see `find_indepedently`).

**Added basic unit tests in `matcher.rs`**
- New hamming dist test with non-zero `free_ns`
- Simple test example with `min_delta == 1`, `max_mismatches == 2`, with expected match and no matches for both matchers
- Programatic test generation for simple examples. Readme examples can be generated and tested with simple function call.

**Tests**
Run...
- Simple matcher tests with `cargo test test_matches`
- Readme example tests with `cargo test test_readme_examples`