### PR TITLE
Change column names for per sample and per project metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,7 +340,7 @@ This file always produced and contains the following columns:
 |------|-----------|
 |`sample_ID`|The name for the sample barcode, typically the same name from the SampleSheet.|
 |`barcode`|The sample barcode bases. Dual index barcodes will have two sample barcode sequences delimited by a `+`.|
-|`templates`|The total number of templates matching the given barcode.|
+|`total_matches`|The total number of templates matching the given barcode.|
 |`perfect_matches`|The number of templates that match perfectly the given barcode.|
 |`one_mismatch_matches`|The number of pass-filter templates that match the given barcode with exactly one mismatch.|
 |`q20_bases`|The number of bases in a template with a quality score 20 or above.|

--- a/README.md
+++ b/README.md
@@ -338,7 +338,7 @@ This file always produced and contains the following columns:
 
 |Column|Description|
 |------|-----------|
-|`barcode_name`|The name for the sample barcode, typically the same name from the SampleSheet.|
+|`sample_ID`|The name for the sample barcode, typically the same name from the SampleSheet.|
 |`barcode`|The sample barcode bases. Dual index barcodes will have two sample barcode sequences delimited by a `+`.|
 |`templates`|The total number of templates matching the given barcode.|
 |`perfect_matches`|The number of templates that match perfectly the given barcode.|

--- a/README.md
+++ b/README.md
@@ -339,7 +339,6 @@ This file always produced and contains the following columns:
 |Column|Description|
 |------|-----------|
 |`barcode_name`|The name for the sample barcode, typically the same name from the SampleSheet.|
-|`library_name`|The name of the library, typically the library identifier from the SampleSheet.|
 |`barcode`|The sample barcode bases. Dual index barcodes will have two sample barcode sequences delimited by a `+`.|
 |`templates`|The total number of templates matching the given barcode.|
 |`perfect_matches`|The number of templates that match perfectly the given barcode.|
@@ -359,7 +358,7 @@ The `per_sample_metrics.tsv` file produces a row per sample.
 
 The `per_project_metrics.tsv` file aggregates the metrics by project (aggregates the metrics across
 samples with the same project) and has the same columns as [per_sample_metrics.tsv](#per_sample_metricstsv).
-In this case, `barcode_name` and `library_name` will contain the project name (or `None` if no
+In this case, `sample_ID` will contain the project name (or `None` if no
 project is given).
 THe `barcode` will contain all `N`s.
 The undetermined sample will not be aggregated with any other sample.

--- a/src/lib/metrics.rs
+++ b/src/lib/metrics.rs
@@ -446,7 +446,7 @@ impl DemuxedGroupSampleMetrics {
         SampleMetricsProcessed {
             sample_id: sample_metadata.sample_id.clone(),
             barcode: sample_metadata.get_semantic_barcode().to_string(),
-            templates: self.total_matches,
+            total_matches: self.total_matches,
             perfect_matches: self.perfect_matches,
             one_mismatch_matches: self.one_mismatch_matches,
             q20_bases: self.base_qual_counter.q20_bases,
@@ -702,7 +702,7 @@ pub struct SampleMetricsProcessed {
     /// The sample barcode bases. Dual index barcodes will have two sample barcode sequences delimited by a `+`.
     pub(crate) barcode: String,
     /// The total number of templates matching the given barcode.
-    pub(crate) templates: usize,
+    pub(crate) total_matches: usize,
     /// The number of templates that match perfectly the given barcode.
     pub(crate) perfect_matches: usize,
     /// The number of pass-filter templates that match the given barcode with exactly one mismatch.
@@ -731,18 +731,16 @@ pub struct SampleMetricsProcessed {
 
 #[cfg(test)]
 mod test {
-    use csv;
     use super::*;
+    use csv;
 
     // Double check that serde does the right thing to rename cols.
     #[test]
     fn test_sample_metrics_col_rename() {
         // Serialize
         let metrics = SampleMetricsProcessed::default();
-        let mut writer = csv::WriterBuilder::new()
-            .has_headers(true)
-            .delimiter(b'\t')
-            .from_writer(vec![]);
+        let mut writer =
+            csv::WriterBuilder::new().has_headers(true).delimiter(b'\t').from_writer(vec![]);
         writer.serialize(&metrics).unwrap();
 
         // Parse the header

--- a/src/lib/metrics.rs
+++ b/src/lib/metrics.rs
@@ -445,7 +445,6 @@ impl DemuxedGroupSampleMetrics {
     ) -> SampleMetricsProcessed {
         SampleMetricsProcessed {
             barcode_name: sample_metadata.sample_id.clone(),
-            library_name: sample_metadata.sample_id.clone(),
             barcode: sample_metadata.get_semantic_barcode().to_string(),
             templates: self.total_matches,
             perfect_matches: self.perfect_matches,
@@ -698,8 +697,6 @@ impl BarcodeCount {
 pub struct SampleMetricsProcessed {
     /// The name for the sample barcode, typically the same name from the SampleSheet.
     pub(crate) barcode_name: String,
-    /// The name of the library, typically the library identifier from the SampleSheet.
-    pub(crate) library_name: String,
     /// The sample barcode bases. Dual index barcodes will have two sample barcode sequences delimited by a `+`.
     pub(crate) barcode: String,
     /// The total number of templates matching the given barcode.

--- a/src/lib/run.rs
+++ b/src/lib/run.rs
@@ -662,7 +662,6 @@ mod test {
         for (metric, sample) in per_sample_metrics.into_iter().zip(sample_sheet.samples.iter()) {
             assert_eq!(metric.barcode_name, *sample.sample_id);
             assert_eq!(metric.barcode, *sample.barcode.to_string());
-            assert_eq!(metric.library_name, *sample.sample_id);
 
             if metric.barcode_name == sample_sheet.samples[0].sample_id {
                 assert_eq!(metric.templates, 2);
@@ -1029,7 +1028,6 @@ mod test {
         for (metric, sample) in per_sample_metrics.into_iter().zip(sample_sheet.samples.iter()) {
             assert_eq!(metric.barcode_name, *sample.sample_id);
             assert_eq!(metric.barcode, *sample.barcode.to_string());
-            assert_eq!(metric.library_name, *sample.sample_id);
 
             if metric.barcode_name == sample_sheet.samples[0].sample_id {
                 assert_eq!(metric.templates, 1);
@@ -1147,7 +1145,6 @@ mod test {
         for (metric, sample) in per_sample_metrics.into_iter().zip(sample_sheet.samples.iter()) {
             assert_eq!(metric.barcode_name, *sample.sample_id);
             assert_eq!(metric.barcode, *sample.barcode.to_string());
-            assert_eq!(metric.library_name, *sample.sample_id);
 
             if metric.barcode_name == sample_sheet.samples[0].sample_id {
                 assert_eq!(metric.templates, templates);

--- a/src/lib/run.rs
+++ b/src/lib/run.rs
@@ -660,14 +660,14 @@ mod test {
         assert_eq!(per_sample_metrics.len(), 5);
 
         for (metric, sample) in per_sample_metrics.into_iter().zip(sample_sheet.samples.iter()) {
-            assert_eq!(metric.barcode_name, *sample.sample_id);
+            assert_eq!(metric.sample_id, *sample.sample_id);
             assert_eq!(metric.barcode, *sample.barcode.to_string());
 
-            if metric.barcode_name == sample_sheet.samples[0].sample_id {
+            if metric.sample_id == sample_sheet.samples[0].sample_id {
                 assert_eq!(metric.templates, 2);
                 assert_eq!(metric.perfect_matches, 1);
                 assert_eq!(metric.one_mismatch_matches, 1);
-            } else if metric.barcode_name == sample_sheet.samples[4].sample_id {
+            } else if metric.sample_id == sample_sheet.samples[4].sample_id {
                 assert_eq!(metric.templates, 3);
                 assert_eq!(metric.perfect_matches, 0);
                 assert_eq!(metric.one_mismatch_matches, 0);
@@ -1026,14 +1026,14 @@ mod test {
             delim.read_tsv(&per_sample_metrics).unwrap();
         assert_eq!(per_sample_metrics.len(), 5);
         for (metric, sample) in per_sample_metrics.into_iter().zip(sample_sheet.samples.iter()) {
-            assert_eq!(metric.barcode_name, *sample.sample_id);
+            assert_eq!(metric.sample_id, *sample.sample_id);
             assert_eq!(metric.barcode, *sample.barcode.to_string());
 
-            if metric.barcode_name == sample_sheet.samples[0].sample_id {
+            if metric.sample_id == sample_sheet.samples[0].sample_id {
                 assert_eq!(metric.templates, 1);
                 assert_eq!(metric.perfect_matches, 1);
                 assert_eq!(metric.one_mismatch_matches, 0);
-            } else if metric.barcode_name == sample_sheet.samples[4].sample_id {
+            } else if metric.sample_id == sample_sheet.samples[4].sample_id {
                 assert_eq!(metric.templates, 0);
                 assert_eq!(metric.perfect_matches, 0);
                 assert_eq!(metric.one_mismatch_matches, 0);
@@ -1143,10 +1143,10 @@ mod test {
         assert_eq!(per_sample_metrics.len(), 5);
 
         for (metric, sample) in per_sample_metrics.into_iter().zip(sample_sheet.samples.iter()) {
-            assert_eq!(metric.barcode_name, *sample.sample_id);
+            assert_eq!(metric.sample_id, *sample.sample_id);
             assert_eq!(metric.barcode, *sample.barcode.to_string());
 
-            if metric.barcode_name == sample_sheet.samples[0].sample_id {
+            if metric.sample_id == sample_sheet.samples[0].sample_id {
                 assert_eq!(metric.templates, templates);
                 assert_eq!(metric.perfect_matches, templates);
                 assert_eq!(metric.one_mismatch_matches, 0);
@@ -1515,15 +1515,15 @@ s2,CCC,GGG"#;
         // One for each barcode and one for undetermined barcodes
         assert_eq!(per_sample_metrics.len(), 3);
 
-        assert_eq!(per_sample_metrics[0].barcode_name, "s1");
+        assert_eq!(per_sample_metrics[0].sample_id, "s1");
         assert_eq!(per_sample_metrics[0].barcode, "TTT+AAA");
         assert_eq!(per_sample_metrics[0].templates, 1);
 
-        assert_eq!(per_sample_metrics[1].barcode_name, "s2");
+        assert_eq!(per_sample_metrics[1].sample_id, "s2");
         assert_eq!(per_sample_metrics[1].barcode, "CCC+GGG");
         assert_eq!(per_sample_metrics[1].templates, 0);
 
-        assert_eq!(per_sample_metrics[2].barcode_name, "Undetermined");
+        assert_eq!(per_sample_metrics[2].sample_id, "Undetermined");
         assert_eq!(per_sample_metrics[2].barcode, "NNNNNN");
         assert_eq!(per_sample_metrics[2].templates, 0);
 
@@ -1584,11 +1584,11 @@ s1,CCC,"#;
         // One for each barcode and one for undetermined barcodes
         assert_eq!(per_sample_metrics.len(), 2);
 
-        assert_eq!(per_sample_metrics[0].barcode_name, "s1");
+        assert_eq!(per_sample_metrics[0].sample_id, "s1");
         assert_eq!(per_sample_metrics[0].barcode, "CCC");
         assert_eq!(per_sample_metrics[0].templates, 0);
 
-        assert_eq!(per_sample_metrics[1].barcode_name, "Undetermined");
+        assert_eq!(per_sample_metrics[1].sample_id, "Undetermined");
         assert_eq!(per_sample_metrics[1].barcode, "NNN");
         assert_eq!(per_sample_metrics[1].templates, 1);
 

--- a/src/lib/run.rs
+++ b/src/lib/run.rs
@@ -664,15 +664,15 @@ mod test {
             assert_eq!(metric.barcode, *sample.barcode.to_string());
 
             if metric.sample_id == sample_sheet.samples[0].sample_id {
-                assert_eq!(metric.templates, 2);
+                assert_eq!(metric.total_matches, 2);
                 assert_eq!(metric.perfect_matches, 1);
                 assert_eq!(metric.one_mismatch_matches, 1);
             } else if metric.sample_id == sample_sheet.samples[4].sample_id {
-                assert_eq!(metric.templates, 3);
+                assert_eq!(metric.total_matches, 3);
                 assert_eq!(metric.perfect_matches, 0);
                 assert_eq!(metric.one_mismatch_matches, 0);
             } else {
-                assert_eq!(metric.templates, 0);
+                assert_eq!(metric.total_matches, 0);
                 assert_eq!(metric.perfect_matches, 0);
                 assert_eq!(metric.one_mismatch_matches, 0);
             }
@@ -1030,15 +1030,15 @@ mod test {
             assert_eq!(metric.barcode, *sample.barcode.to_string());
 
             if metric.sample_id == sample_sheet.samples[0].sample_id {
-                assert_eq!(metric.templates, 1);
+                assert_eq!(metric.total_matches, 1);
                 assert_eq!(metric.perfect_matches, 1);
                 assert_eq!(metric.one_mismatch_matches, 0);
             } else if metric.sample_id == sample_sheet.samples[4].sample_id {
-                assert_eq!(metric.templates, 0);
+                assert_eq!(metric.total_matches, 0);
                 assert_eq!(metric.perfect_matches, 0);
                 assert_eq!(metric.one_mismatch_matches, 0);
             } else {
-                assert_eq!(metric.templates, 0);
+                assert_eq!(metric.total_matches, 0);
                 assert_eq!(metric.perfect_matches, 0);
                 assert_eq!(metric.one_mismatch_matches, 0);
             }
@@ -1147,7 +1147,7 @@ mod test {
             assert_eq!(metric.barcode, *sample.barcode.to_string());
 
             if metric.sample_id == sample_sheet.samples[0].sample_id {
-                assert_eq!(metric.templates, templates);
+                assert_eq!(metric.total_matches, templates);
                 assert_eq!(metric.perfect_matches, templates);
                 assert_eq!(metric.one_mismatch_matches, 0);
                 assert_eq!(metric.total_number_of_bases, total_num_bases);
@@ -1156,7 +1156,7 @@ mod test {
                 assert_eq!(metric.frac_q20_bases, q20_above as f64 / total_num_bases as f64);
                 assert_eq!(metric.frac_q30_bases, q30_above as f64 / total_num_bases as f64);
             } else {
-                assert_eq!(metric.templates, 0);
+                assert_eq!(metric.total_matches, 0);
                 assert_eq!(metric.perfect_matches, 0);
                 assert_eq!(metric.one_mismatch_matches, 0);
                 assert_eq!(metric.total_number_of_bases, 0);
@@ -1517,15 +1517,15 @@ s2,CCC,GGG"#;
 
         assert_eq!(per_sample_metrics[0].sample_id, "s1");
         assert_eq!(per_sample_metrics[0].barcode, "TTT+AAA");
-        assert_eq!(per_sample_metrics[0].templates, 1);
+        assert_eq!(per_sample_metrics[0].total_matches, 1);
 
         assert_eq!(per_sample_metrics[1].sample_id, "s2");
         assert_eq!(per_sample_metrics[1].barcode, "CCC+GGG");
-        assert_eq!(per_sample_metrics[1].templates, 0);
+        assert_eq!(per_sample_metrics[1].total_matches, 0);
 
         assert_eq!(per_sample_metrics[2].sample_id, "Undetermined");
         assert_eq!(per_sample_metrics[2].barcode, "NNNNNN");
-        assert_eq!(per_sample_metrics[2].templates, 0);
+        assert_eq!(per_sample_metrics[2].total_matches, 0);
 
         // Check unmatched batcode metrics, should be empty
         let unmatched_metrics = output.join("most_frequent_unmatched.tsv");
@@ -1586,11 +1586,11 @@ s1,CCC,"#;
 
         assert_eq!(per_sample_metrics[0].sample_id, "s1");
         assert_eq!(per_sample_metrics[0].barcode, "CCC");
-        assert_eq!(per_sample_metrics[0].templates, 0);
+        assert_eq!(per_sample_metrics[0].total_matches, 0);
 
         assert_eq!(per_sample_metrics[1].sample_id, "Undetermined");
         assert_eq!(per_sample_metrics[1].barcode, "NNN");
-        assert_eq!(per_sample_metrics[1].templates, 1);
+        assert_eq!(per_sample_metrics[1].total_matches, 1);
 
         // Check unmatched batcode metrics, should be empty
         let unmatched_metrics = output.join("most_frequent_unmatched.tsv");


### PR DESCRIPTION
Completes tasks in #59

Todos:
- [ ] add to a changelog or release notes. Changes to struct field members and serialized TSV cols constitute a breaking change