### PR TITLE
`+` delimited dual index barcodes, and arbitrary raw barcodes

### DIFF
--- a/src/lib/demux.rs
+++ b/src/lib/demux.rs
@@ -548,9 +548,10 @@ where
                 {
                     tracker.check_barcode(&barcode);
                 }
-                // If collection of top unmatched barcodes is in effect, track this barcode
+                // If collection of top unmatched barcodes is in effect, track this
+                // barcode in its **semantic** delimited form
                 if let Some(ref mut unmatched) = demuxed_group.unmatched {
-                    unmatched.push(barcode);
+                    unmatched.push(delim.clone());
                 }
             }
 

--- a/src/lib/metrics.rs
+++ b/src/lib/metrics.rs
@@ -370,12 +370,19 @@ impl<'a> DemuxedGroupMetrics<'a> {
             let filename =
                 [prefix.to_string(), "sample_barcode_hop_metrics.tsv".to_string()].concat();
             let output_path = output_dir.as_ref().join(filename);
+
+            let b1_len = sample_barcode_hop_tracker.checker.index1_length;
             delim.write_tsv(
                 &output_path,
                 sample_barcode_hop_tracker
                     .count_tracker
                     .into_iter()
-                    .map(|(barcode, count)| BarcodeCount::new(barcode.into(), count as isize))
+                    .map(|(barcode, count)| {
+                        let b1 = BString::from(&barcode[..b1_len]);
+                        let b2 = BString::from(&barcode[b1_len..]);
+                        let barcode = BString::from(format!("{}+{}", b1, b2));
+                        BarcodeCount::new(barcode, count as isize)
+                    })
                     .sorted_unstable_by_key(|b| -b.count),
             )?;
         }

--- a/src/lib/metrics.rs
+++ b/src/lib/metrics.rs
@@ -439,7 +439,7 @@ impl DemuxedGroupSampleMetrics {
         SampleMetricsProcessed {
             barcode_name: sample_metadata.sample_id.clone(),
             library_name: sample_metadata.sample_id.clone(),
-            barcode: sample_metadata.barcode.to_string(),
+            barcode: sample_metadata.get_semantic_barcode().to_string(),
             templates: self.total_matches,
             perfect_matches: self.perfect_matches,
             one_mismatch_matches: self.one_mismatch_matches,

--- a/src/lib/metrics.rs
+++ b/src/lib/metrics.rs
@@ -678,7 +678,7 @@ impl<'a> SampleBarcodeHopTracker<'a> {
 }
 
 /// A helper struct fot serializing and deserializing barcode counts.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub(crate) struct BarcodeCount {
     /// The barcode.
     pub(crate) barcode: String,

--- a/src/lib/run.rs
+++ b/src/lib/run.rs
@@ -1379,4 +1379,148 @@ mod test {
         assert_eq!(std::str::from_utf8(&i1s[0].seq).unwrap(), "GGTCAGAT"); // no masking
         assert_eq!(std::str::from_utf8(&u1s[0].seq).unwrap(), "ACGTAA"); // no masking
     }
+
+    #[rstest]
+    #[allow(clippy::too_many_lines)]
+    fn test_dual_index_hop_metrics() {
+        let dir = tempfile::tempdir().unwrap();
+        let fastqs = vec!["r1", "r2"]
+            .into_iter()
+            .map(|name| dir.path().join(format!("{}.fastq.gz", name)))
+            .collect_vec();
+
+        let read_structures = vec![
+            ReadStructure::from_str("3B+T").unwrap(), // 6bp UMI then template
+            ReadStructure::from_str("3B+T").unwrap(), // just template
+        ];
+
+        let r1 = Fq {
+            name: "q1",
+            bases: b"TTTCCC", //
+            quals: Some(b"IIICCC"),
+            ..Fq::default()
+        };
+        let r2 = Fq {
+            name: "q2",
+            bases: b"AAACCC", //
+            quals: Some(b"IIICCC"),
+            ..Fq::default()
+        };
+
+        for (fastq, read) in fastqs.iter().zip(vec![r1, r2].iter()) {
+            write_reads_to_file(std::iter::once(read.to_owned_record()), fastq);
+        }
+
+        let output = dir.path().join("output");
+        create_dir(&output).unwrap();
+
+        // Two barcodes for reads to hop
+        let metadata = dir.path().join("samples.csv");
+        let metadata_txt = r#"[Demux]
+[Data]
+Sample_ID,Index1_Sequence,Index2_Sequence
+s1,TTT,GGG
+s2,CCC,AAA"#;
+
+        std::fs::write(&metadata, metadata_txt).expect("Failed to write sample metadata.");
+
+        let opts = Opts {
+            fastqs,
+            output_dir: output.clone(),
+            sample_metadata: metadata.clone(),
+            read_structures,
+            output_types: "TB".to_owned(),
+            ..Opts::default()
+        };
+
+        let sample_sheet = SampleSheet::from_path(opts).unwrap();
+        run(sample_sheet.opts).unwrap();
+
+        // Check metrics
+        let hop_metrics = output.join("sample_barcode_hop_metrics.tsv");
+
+        let delim = DelimFile::default();
+        let hop_metrics: Vec<BarcodeCount> = delim.read_tsv(&hop_metrics).unwrap();
+        assert_eq!(hop_metrics.len(), 1);
+        assert_eq!(hop_metrics[0].barcode, "TTT+AAA");
+        assert_eq!(hop_metrics[0].count, 1);
+    }
+
+    #[rstest]
+    #[allow(clippy::too_many_lines)]
+    fn test_dual_index_sample_metrics() {
+        let dir = tempfile::tempdir().unwrap();
+        let fastqs = vec!["r1", "r2"]
+            .into_iter()
+            .map(|name| dir.path().join(format!("{}.fastq.gz", name)))
+            .collect_vec();
+
+        let read_structures = vec![
+            ReadStructure::from_str("3B+T").unwrap(), // 6bp UMI then template
+            ReadStructure::from_str("3B+T").unwrap(), // just template
+        ];
+
+        let r1 = Fq {
+            name: "q1",
+            bases: b"TTTCCC", //
+            quals: Some(b"IIICCC"),
+            ..Fq::default()
+        };
+        let r2 = Fq {
+            name: "q2",
+            bases: b"AAACCC", //
+            quals: Some(b"IIICCC"),
+            ..Fq::default()
+        };
+
+        for (fastq, read) in fastqs.iter().zip(vec![r1, r2].iter()) {
+            write_reads_to_file(std::iter::once(read.to_owned_record()), fastq);
+        }
+
+        let output = dir.path().join("output");
+        create_dir(&output).unwrap();
+
+        // Reads map to s1
+        let metadata = dir.path().join("samples.csv");
+        let metadata_txt = r#"[Demux]
+[Data]
+Sample_ID,Index1_Sequence,Index2_Sequence
+s1,TTT,AAA
+s2,CCC,GGG"#;
+
+        std::fs::write(&metadata, metadata_txt).expect("Failed to write sample metadata.");
+
+        let opts = Opts {
+            fastqs,
+            output_dir: output.clone(),
+            sample_metadata: metadata,
+            read_structures,
+            output_types: "TB".to_owned(),
+            ..Opts::default()
+        };
+
+        let sample_sheet = SampleSheet::from_path(opts).unwrap();
+        run(sample_sheet.opts).unwrap();
+
+        // Check metrics
+        let per_sample_metrics = output.join("per_sample_metrics.tsv");
+        let delim = DelimFile::default();
+        let per_sample_metrics: Vec<SampleMetricsProcessed> =
+            delim.read_tsv(&per_sample_metrics).unwrap();
+
+        // One for each barcode and one for undetermined barcodes
+        assert_eq!(per_sample_metrics.len(), 3);
+
+        assert_eq!(per_sample_metrics[0].barcode_name, "s1");
+        assert_eq!(per_sample_metrics[0].barcode, "TTT+AAA");
+        assert_eq!(per_sample_metrics[0].templates, 1);
+
+        assert_eq!(per_sample_metrics[1].barcode_name, "s2");
+        assert_eq!(per_sample_metrics[1].barcode, "CCC+GGG");
+        assert_eq!(per_sample_metrics[1].templates, 0);
+
+        assert_eq!(per_sample_metrics[2].barcode_name, "Undetermined");
+        assert_eq!(per_sample_metrics[2].barcode, "NNNNNN");
+        assert_eq!(per_sample_metrics[2].templates, 0);
+    }
 }

--- a/src/lib/run.rs
+++ b/src/lib/run.rs
@@ -1442,8 +1442,7 @@ s2,CCC,AAA"#;
         let delim = DelimFile::default();
         let hop_metrics: Vec<BarcodeCount> = delim.read_tsv(&hop_metrics).unwrap();
         assert_eq!(hop_metrics.len(), 1);
-        assert_eq!(hop_metrics[0].barcode, "TTT+AAA");
-        assert_eq!(hop_metrics[0].count, 1);
+        assert_eq!(hop_metrics[0], BarcodeCount { barcode: "TTT+AAA".to_string(), count: 1 });
 
         // Check unmatched metric, should contain the one hopped barcode
         let unmatched_metrics = output.join("most_frequent_unmatched.tsv");
@@ -1451,8 +1450,7 @@ s2,CCC,AAA"#;
         let delim = DelimFile::default();
         let unmatched_metrics: Vec<BarcodeCount> = delim.read_tsv(&unmatched_metrics).unwrap();
         assert_eq!(unmatched_metrics.len(), 1);
-        assert_eq!(unmatched_metrics[0].barcode, "TTT+AAA");
-        assert_eq!(unmatched_metrics[0].count, 1);
+        assert_eq!(unmatched_metrics[0], BarcodeCount { barcode: "TTT+AAA".to_string(), count: 1 });
     }
 
     #[rstest]
@@ -1602,7 +1600,7 @@ s1,CCC,"#;
         let delim = DelimFile::default();
         let unmatched_metrics: Vec<BarcodeCount> = delim.read_tsv(&unmatched_metrics).unwrap();
         assert_eq!(unmatched_metrics.len(), 1);
-        assert_eq!(unmatched_metrics[0].barcode, "TTT");
+        assert_eq!(unmatched_metrics[0], BarcodeCount { barcode: "TTT".to_string(), count: 1 });
 
         // make sure that hop metrics does not exist
         let hop_metrics = output.join("sample_barcode_hop_metrics.tsv");


### PR DESCRIPTION
Addresses #60. 

We now term barcodes delimited by "+" a "semantic" barcode --- a representation that is a 1-1 mapping between a fixed length barcodes (e.g, `AAA+CCC`) and  its read structure `3B3B`.

### Tasks
- [x] update per_sample_metrics.tsv and per_project_metrics.tsv
- [x] update sample_barcode_hop_,metrics.tsv
- [x] update most_frequent_unmatched.tsv 

### Details for per-sample metrics

When using sample sheets, dual index barcodes are reported in metrics with `+` delimiter.

For example, the sample sheet:
```
[Demux]
[Data]
Sample_ID,Index1_Sequence,Index2_Sequence
s1,CCCCC,AAAAA
```

yields a barcode for `s1` that appear as `CCCCC+AAAAA`

When using two-column format _**arbitrary**_ barcodes are allowed. For example:
```
Sample_ID,Sample_Barcode
s1,TTT+=!-AAA
``` 

yields a barcode for `s1` that appear as `TTT+=!-AAA`.

### Details for sample barcode hop and unmatched barcode metrics
Barcodes now also appear also in their delimited semantic representations

### Tests
- For extracting semantic barcode representations from `SampleMetadata`, the above mentioned behaviors are now tested and exampled in included explicit test cases.
- Added end-to-end tests with small examples to check basic values in output per-sample and barcode hopping metrics.

### Future Todos
- [ ] Add release note and review updates to README
- ~Design schema for displaying and reading multi-segment barcodes~
- ~Validate multi-segment barcodes. As reflected in the test and implementation, we allow for arbitrary barcodes.~