### PR TITLE
Pin and lock cross version

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,7 +24,7 @@ jobs:
       matrix:
         build: [linux, linux-arm, macos, win-msvc, win-gnu]
         include:
-          # TODO: 
+          # TODO:
           # - arm-unknown-linux-musleabihf
           # - aarch64-unknown-linux-gnu
           # - i686-unknown-linux-gnu
@@ -78,9 +78,9 @@ jobs:
         shell: bash
         if: ${{ matrix.use-cross == true }}
         run: |
-          cargo install cross
+          cargo install cross@0.2.5 --locked
           echo "CARGO=cross" >> $GITHUB_ENV
-      
+
       - name: Set target environment variables
         shell: bash
         run: |


### PR DESCRIPTION
`cargo install cross` was breaking CI because an older ver `1.64.0` version of `rustc`. Issue caused by packages required by `cross` that have bumped minor semver versions when increasing the MSRV.

`cargo install cross@0.2.5 --locked` respects the Lockfile of `cross` and fixes this.